### PR TITLE
Bug - Weekly with recurCount

### DIFF
--- a/grails-app/domain/com/craigburke/Event.groovy
+++ b/grails-app/domain/com/craigburke/Event.groovy
@@ -59,7 +59,10 @@ class Event {
         if (recurCount && !recurUntil) {
            Date recurCountDate = startTime
 
-           for (int i in 1..(recurCount - 1)) {
+           // extra instance if startTime day is not in recurDaysOfWeek
+           def extraInstance = this.recurType == EventRecurType.WEEKLY && !(eventService.isOnRecurringDay(this, this.startTime)) ? 1 : 0
+
+           for (int i in 1..(recurCount - 1 + extraInstance)) {
                recurCountDate = eventService.findNextOccurrence(this, new DateTime(recurCountDate).plusMinutes(1).toDate())
            }
 


### PR DESCRIPTION
When the recurCount value is selected and the start day is not on the recurDaysOfWeek the event recurs recurCount - 1 times.
Example:
Recur weekly on Mondays, starts today (for example today is Friday), recur 2 times -> will recur 1 time.
In Google Calendar this same event would recur 2 times.
